### PR TITLE
Fix define-c

### DIFF
--- a/lib.l
+++ b/lib.l
@@ -1,7 +1,8 @@
 ;; -*- mode: lisp -*-
 
 (define-macro define-c (v x)
-  (cat "|" v ".cdef[[" (inner x) "]]|"))
+  `(let cdef ,(cat "|" v ".cdef[[" (inner x) "]]|")
+     cdef))
 
 (define-macro resume args
   `(coroutine.resume ,@args))


### PR DESCRIPTION
`lib.l`:
- Fix the `define-c` macro
  - Previously, calling `(define-c ffi |... code ...|)` resulted in no compiler output whatsoever
  - Will investigate why.  In the meantime, this workaround works.
